### PR TITLE
 Manually trigger analysis for specific products

### DIFF
--- a/server/app/queue-handling/review.server.ts
+++ b/server/app/queue-handling/review.server.ts
@@ -309,3 +309,31 @@ export async function analyzeProduct(product_id: string) {
 
   channel.sendToQueue("to_analyze", Buffer.from(JSON.stringify(reviews)));
 }
+
+export async function clearParseQueue() {
+  if (!connection) {
+    await connectionPromise;
+    if (!connection) throw new Error("Queue connection not set up");
+  }
+
+  const channel = await connection.createChannel();
+  await channel.assertQueue("parse", {
+    durable: true,
+  });
+
+  channel.purgeQueue("parse");
+}
+
+export async function clearToAnalyzeQueue() {
+  if (!connection) {
+    await connectionPromise;
+    if (!connection) throw new Error("Queue connection not set up");
+  }
+
+  const channel = await connection.createChannel();
+  await channel.assertQueue("to_analyze", {
+    durable: true,
+  });
+
+  channel.purgeQueue("to_analyze");
+}

--- a/server/app/queue-handling/review.server.ts
+++ b/server/app/queue-handling/review.server.ts
@@ -293,3 +293,19 @@ export async function sendProductToQueue(product: Product) {
 
   channel.sendToQueue("parse", Buffer.from(JSON.stringify(product)));
 }
+
+export async function analyzeProduct(product_id: string) {
+  if (!connection) {
+    await connectionPromise;
+    if (!connection) throw new Error("Queue connection not set up");
+  }
+
+  const channel = await connection.createChannel();
+  const reviews = await db.review.findMany({
+    where: {
+      product_id,
+    },
+  });
+
+  channel.sendToQueue("to_analyze", Buffer.from(JSON.stringify(reviews)));
+}

--- a/server/app/routes/admin.product.$productId.tsx
+++ b/server/app/routes/admin.product.$productId.tsx
@@ -1,0 +1,187 @@
+import type { SerializeFrom } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { Card, Title } from "@tremor/react";
+import { db } from "~/utils/db.server";
+
+export const loader = async ({ params }: { params: { productId: string } }) => {
+  const reviews = await db.review.findMany({
+    where: {
+      product_id: params.productId,
+    },
+    include: {
+      reports: {
+        include: {
+          issues: {
+            include: {
+              images: true,
+            },
+          },
+          reliability_keyframes: true,
+        },
+      },
+      images: true,
+    },
+  });
+
+  return json(reviews);
+};
+
+export default function Index() {
+  const reviews = useLoaderData<typeof loader>();
+
+  return (
+    <div className="mx-4 h-full content-center items-center space-y-4 pt-4 text-center md:container md:mx-auto">
+      <h1 className="text-2xl font-bold">Admin: Analyze Products</h1>
+
+      <div className="flex flex-row flex-wrap">
+        {reviews && getReviewBoxes(reviews)}
+      </div>
+    </div>
+  );
+}
+
+function getReviewBoxes(reviews: SerializeFrom<typeof loader>) {
+  return reviews.map((review) => {
+    return (
+      <Card key={review.id} className="m-5 grow basis-1/3">
+        <Title>{review.text}</Title>
+        <div className="my-3">
+          <div>
+            <b>By</b>: {review.author_name}
+            {review.author_image_url && (
+              <img
+                src={review.author_image_url}
+                alt={`Avatar for ${review.author_name}`}
+              />
+            )}
+          </div>
+          <div>
+            <b>Scraped on</b>: {review.createdAt}
+          </div>
+          <div>
+            <b>Rewiewed on</b>: {review.date}
+          </div>
+          <div>
+            <b>Country</b>: {review.country_reviewed_in}
+          </div>
+          <div>
+            <b>Region</b>: {review.region}
+          </div>
+          <div>
+            <b>Verified Purchase</b>: {review.verified_purchase ? "Yes" : "No"}
+          </div>
+          <div>
+            <b>Found Helpful</b>: {review.found_helpful_count}
+          </div>
+          <div>
+            <b>Top Positive</b>: {review.is_top_positive_review ? "Yes" : "No"}
+          </div>
+          <div>
+            <b>Top Critical</b>: {review.is_top_critical_review ? "Yes" : "No"}
+          </div>
+          {!!review.attributes && (
+            <div>
+              <b>Attributes</b>:{" "}
+              {Object.entries(review.attributes as Record<string, string>)
+                ?.map((a) => `${a[0]}: ${a[1]}`)
+                ?.join(", ")}
+            </div>
+          )}
+          {review.images?.length > 0 && (
+            <div>
+              <b>Images</b>:{" "}
+              {review.images.map((image) => (
+                // eslint-disable-next-line jsx-a11y/img-redundant-alt
+                <img
+                  key={image.image_url}
+                  src={image.image_url}
+                  alt="Photo Submitted By Author"
+                />
+              ))}
+            </div>
+          )}
+
+          {review.reports?.length > 0 && (
+            <div>
+              <b>Reports</b>:{" "}
+              {review.reports.map((report) => (
+                <div key={report.id} className="border-4">
+                  <div>
+                    <b>ID</b>: {report.id}
+                  </div>
+                  <div>
+                    <b>Weight</b>: {report.report_weight}
+                  </div>
+
+                  {report.issues?.length > 0 && (
+                    <div>
+                      <b>Issues</b>:{" "}
+                      {report.issues.map((issue) => (
+                        <div key={issue.id} className="border-4">
+                          <div>
+                            <b>ID</b>: {issue.id}
+                          </div>
+                          <div>
+                            <b>Text</b>: {issue.text}
+                          </div>
+                          <div>
+                            <b>Criticality</b>: {issue.criticality}
+                          </div>
+                          <div>
+                            <b>Relative Timestamp</b>: {issue.rel_timestamp}
+                          </div>
+                          <div>
+                            <b>Frequency</b>: {issue.frequency}
+                          </div>
+                          {issue.images?.length > 0 && (
+                            <div>
+                              <b>Images</b>:{" "}
+                              {issue.images.map((image) => (
+                                // eslint-disable-next-line jsx-a11y/img-redundant-alt
+                                <img
+                                  key={image.image_url}
+                                  src={image.image_url}
+                                  alt="Photo of product"
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {report.reliability_keyframes?.length > 0 && (
+                    <div>
+                      <b>Reliability Keyframes</b>:{" "}
+                      {report.reliability_keyframes.map(
+                        (reliability_keyframe) => (
+                          <div key={reliability_keyframe.id}>
+                            <div>
+                              <b>ID</b>: {reliability_keyframe.id}
+                            </div>
+                            <div>
+                              <b>Relative Timestamp</b>:{" "}
+                              {reliability_keyframe.rel_timestamp}
+                            </div>
+                            <div>
+                              <b>Sentiment</b>: {reliability_keyframe.sentiment}
+                            </div>
+                            <div>
+                              <b>Interp</b>: {reliability_keyframe.interp}
+                            </div>
+                          </div>
+                        )
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Card>
+    );
+  });
+}

--- a/server/app/routes/admin.products.($pageNum).tsx
+++ b/server/app/routes/admin.products.($pageNum).tsx
@@ -2,7 +2,7 @@ import type { Product } from "@prisma/client";
 import type { ActionFunction, SerializeFrom } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import type { SubmitFunction } from "@remix-run/react";
-import { useLoaderData, useSubmit } from "@remix-run/react";
+import { Link, useLoaderData, useSubmit } from "@remix-run/react";
 import { Button, Card, Title } from "@tremor/react";
 import { analyzeProduct } from "~/queue-handling/review.server";
 import { db } from "~/utils/db.server";
@@ -139,6 +139,10 @@ function getProductBoxes(
             <b>Updated on</b>: {product.updatedAt}
           </div>
         </div>
+
+        <Link to={`/admin/product/${product.id}`}>
+          <Button className="mt-4 block">View Product Information</Button>
+        </Link>
 
         <Button
           type="submit"

--- a/server/app/routes/admin.products.($pageNum).tsx
+++ b/server/app/routes/admin.products.($pageNum).tsx
@@ -1,0 +1,179 @@
+import type { Product } from "@prisma/client";
+import type { ActionFunction, SerializeFrom } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import type { SubmitFunction } from "@remix-run/react";
+import { useLoaderData, useSubmit } from "@remix-run/react";
+import { Button, Card, Title } from "@tremor/react";
+import { analyzeProduct } from "~/queue-handling/review.server";
+import { db } from "~/utils/db.server";
+
+interface ProductData extends Product {
+  reportCount: number;
+  reviewCount: number;
+}
+
+export const action: ActionFunction = async ({ request }) => {
+  const { type, productId } = Object.fromEntries(await request.formData());
+  if (
+    typeof type !== "string" ||
+    type.length === 0 ||
+    typeof productId !== "string" ||
+    productId.length === 0
+  ) {
+    return null;
+  }
+
+  switch (type) {
+    case "clearReport": {
+      await db.$transaction([
+        db.issue.deleteMany({
+          where: {
+            report: {
+              review: {
+                product_id: productId,
+              },
+            },
+          },
+        }),
+        db.reliabilityKeyframe.deleteMany({
+          where: {
+            report: {
+              review: {
+                product_id: productId,
+              },
+            },
+          },
+        }),
+        db.report.deleteMany({
+          where: {
+            review: {
+              product_id: productId,
+            },
+          },
+        }),
+      ]);
+      break;
+    }
+    case "analyzeReviews": {
+      await analyzeProduct(productId);
+      break;
+    }
+  }
+
+  return null;
+};
+
+export const loader = async ({ params }: { params: { pageNum: string } }) => {
+  const page = parseInt(params.pageNum, 10) || 1;
+  const pageSize = 100;
+
+  const products = await Promise.all(
+    (
+      await db.product.findMany({
+        where: {},
+        orderBy: {
+          createdAt: "desc",
+        },
+        take: pageSize,
+        skip: pageSize * (page - 1),
+      })
+    ).map(async (product) => ({
+      ...product,
+      reportCount: await db.report.count({
+        where: {
+          review: {
+            product_id: product.id,
+          },
+        },
+      }),
+      reviewCount: await db.review.count({
+        where: {
+          product_id: product.id,
+        },
+      }),
+    }))
+  );
+  return json(products);
+};
+
+export default function Index() {
+  const products = useLoaderData<typeof loader>();
+  const submit = useSubmit();
+
+  return (
+    <div className="mx-4 h-full content-center items-center space-y-4 pt-4 text-center md:container md:mx-auto">
+      <h1 className="text-2xl font-bold">Admin: Analyze Products</h1>
+
+      <div className="flex flex-row flex-wrap">
+        {products && getProductBoxes(products, submit)}
+      </div>
+    </div>
+  );
+}
+
+function getProductBoxes(
+  products: SerializeFrom<ProductData>[],
+  submit: SubmitFunction
+) {
+  return products.map((product) => {
+    return (
+      <Card key={product.id} className="m-5 grow basis-72">
+        <Title>{product.name}</Title>
+        <div className="my-3">
+          <div>
+            <b>ID</b>: {product.id}
+          </div>
+          <div>
+            <b>Name</b>: {product.name}
+          </div>
+          <div>
+            <b>Reviews</b>: {product.reviewCount}
+          </div>
+          <div>
+            <b>Reports</b>: {product.reportCount}
+          </div>
+          <div>
+            <b>Created on</b>: {product.createdAt}
+          </div>
+          <div>
+            <b>Updated on</b>: {product.updatedAt}
+          </div>
+        </div>
+
+        <Button
+          type="submit"
+          className="mt-4 block"
+          onClick={() => {
+            if (confirm("Are you sure you would like to clear all reports?")) {
+              submit(
+                { type: "clearReport", productId: product.id },
+                {
+                  preventScrollReset: true,
+                  method: "post",
+                }
+              );
+            }
+          }}
+        >
+          Clear Reports
+        </Button>
+
+        <Button
+          type="submit"
+          className="mt-4 block"
+          onClick={() => {
+            submit(
+              { type: "analyzeReviews", productId: product.id },
+              {
+                preventScrollReset: true,
+                method: "post",
+              }
+            );
+          }}
+        >
+          Analyze Reviews
+        </Button>
+      </Card>
+    );
+  });
+}

--- a/server/app/routes/admin.reviews.($pageNum).tsx
+++ b/server/app/routes/admin.reviews.($pageNum).tsx
@@ -26,7 +26,7 @@ interface ReviewData {
 }
 
 export const loader = async ({ params }: { params: { pageNum: string } }) => {
-  const page = parseInt(params.pageNum, 10) || 0;
+  const page = parseInt(params.pageNum, 10) || 1;
   const pageSize = 10;
 
   return json<ReviewData[] | null>(
@@ -55,7 +55,7 @@ export const loader = async ({ params }: { params: { pageNum: string } }) => {
       orderBy: {
         createdAt: "desc",
       },
-      skip: page * pageSize,
+      skip: (page - 1) * pageSize,
       take: pageSize,
     })
   );


### PR DESCRIPTION
Adds new admin page to manage status of products in the database, clear the existing parsed reports and rerun analysis.

Will make testing the analyzer on real data easier.

![image](https://github.com/6monthslater/6monthslater/assets/12688112/526767b1-80ee-4bd0-a058-f1a479a76b82)

Fixes #56