### PR TITLE
Add default cookie for running tests with an empty config

### DIFF
--- a/scraper/utils/env.py
+++ b/scraper/utils/env.py
@@ -3,5 +3,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+defaults = {
+    "AMAZON_COOKIE": "csm-sid=568-8411815-1797105; session-id=140-6102862-5001741; session-id-time=2082787201l"
+}
+
 def get_env(name: str) -> str | None:
     return os.getenv(name)


### PR DESCRIPTION
Default cookie will allow you to successfully run tests without setting up a cookie in the env file yourself