### PR TITLE
Allow analyzer to support both data directly from scraper as well as from the "analyze" button

### DIFF
--- a/scraper/listener/analyzer.py
+++ b/scraper/listener/analyzer.py
@@ -102,7 +102,7 @@ def __analyze_reviews(reviews: list[dict[str, Any]]) -> list[Report]:
             author_image_url=review["author_image_url"],
             title=review["title"],
             text=review["text"],
-            date=int(dp.parse(review["date"]).timestamp()),
+            date=review["date"] if isinstance(review["date"], int) else int(dp.parse(review["date"]).timestamp()),
             date_text=review["date_text"],
             review_id=review["review_id"],
             attributes=review["attributes"],
@@ -113,9 +113,9 @@ def __analyze_reviews(reviews: list[dict[str, Any]]) -> list[Report]:
             images=review["images"],
             country_reviewed_in=review["country_reviewed_in"],
             region=AmazonRegion(review["region"]),
-            product_name=review["product"]["name"],
-            manufacturer_name=review["product"]["manufacturer"]["name"],
-            manufacturer_id=review["product"]["manufacturer"]["id"]
+            product_name=review["product_name"],
+            manufacturer_name=review["manufacturer_name"],
+            manufacturer_id=review["manufacturer_id"]
         ) for review in reviews])
 
 def __analyze_reviews_using_llm(reviews: list[dict[str, Any]]) -> list[Report]:

--- a/server/app/queue-handling/review.server.ts
+++ b/server/app/queue-handling/review.server.ts
@@ -302,19 +302,26 @@ export async function analyzeProduct(product_id: string) {
   }
 
   const channel = await connection.createChannel();
-  const reviews = await db.review.findMany({
-    where: {
-      product_id,
-    },
-    include: {
-      product: {
-        include: {
-          manufacturer: true,
-        },
+  const reviews = (
+    await db.review.findMany({
+      where: {
+        product_id,
       },
-      images: true,
-    },
-  });
+      include: {
+        product: {
+          include: {
+            manufacturer: true,
+          },
+        },
+        images: true,
+      },
+    })
+  ).map((review) => ({
+    ...review,
+    product_name: review.product.name,
+    manufacturer_name: review.product.manufacturer.name,
+    manufacturer_id: review.product.manufacturer.id,
+  }));
 
   channel.sendToQueue("to_analyze", Buffer.from(JSON.stringify(reviews)));
 }


### PR DESCRIPTION
Before, it was only working when using the manual "analysis" button in the UI. This makes sure both use the same analysis request format