### PR TITLE
feat: improve error handling

### DIFF
--- a/server/app/routes/_index.tsx
+++ b/server/app/routes/_index.tsx
@@ -3,7 +3,13 @@ import { TbSearch } from "react-icons/tb";
 import { Button } from "~/components/shadcn-ui-mod/button";
 import type { ActionArgs, MetaFunction } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
-import { Form, useFetcher, useNavigate, useSubmit } from "@remix-run/react";
+import {
+  Form,
+  useActionData,
+  useFetcher,
+  useNavigate,
+  useSubmit,
+} from "@remix-run/react";
 import { db } from "~/utils/db.server";
 import { getProductImageUrl } from "~/utils/amazon";
 import { Combobox, Transition } from "@headlessui/react";
@@ -26,7 +32,7 @@ export async function action({ request }: ActionArgs) {
   const body = await request.formData();
   const productName = body.get("productName");
   if (!productName) {
-    return json({ errors: ["No Product Name provided"] }, { status: 400 });
+    return json({ error: "No Product Name provided" }, { status: 400 });
   }
 
   const searchTerm = createSearchTerm(productName.toString());
@@ -65,7 +71,7 @@ export async function action({ request }: ActionArgs) {
     },
   });
   if (!data) {
-    return json({ errors: ["Product not found"] }, { status: 400 });
+    return json({ error: "Product not found" }, { status: 400 });
   }
   return redirect(`/product/${data.id}`);
 }
@@ -138,6 +144,7 @@ function createSearchTerm(productName: string) {
 export default function Index() {
   const [searchProdName, setSearchProdName] = useState("");
   const searchSuggestionFetcher = useFetcher<typeof loader>();
+  const actionData = useActionData<typeof action>();
   const [currentSuggestions, setCurrentSuggestions] = useState<Suggestion[]>(
     []
   );
@@ -231,6 +238,12 @@ export default function Index() {
               </Transition>
             )}
           </Combobox>
+          <p
+            className={`text-center text-sm text-red-500`}
+            hidden={!actionData?.error}
+          >
+            {actionData?.error}
+          </p>
 
           <Button className="my-3" type="submit">
             <TbSearch className="mr-2 h-4 w-4" /> Search

--- a/server/app/routes/_index.tsx
+++ b/server/app/routes/_index.tsx
@@ -15,6 +15,8 @@ import { getProductImageUrl } from "~/utils/amazon";
 import { Combobox, Transition } from "@headlessui/react";
 import { Separator } from "~/components/ui/separator";
 import { WEBSITE_TITLE } from "~/root";
+import type { PrismaClientError } from "~/types/PrismaClientError";
+import { PRISMA_ERROR_MSG } from "~/types/PrismaClientError";
 
 interface Suggestion {
   name: string;
@@ -37,20 +39,24 @@ export async function action({ request }: ActionArgs) {
 
   const searchTerm = createSearchTerm(productName.toString());
 
-  const data = await db.product.findFirst({
-    where: {
-      name: {
-        search: searchTerm,
-        mode: "insensitive",
-      },
-      reviews: {
-        some: {
-          reports: {
-            some: {
-              issues: {
-                some: {
-                  text: {
-                    not: "",
+  let data;
+
+  try {
+    data = await db.product.findFirst({
+      where: {
+        name: {
+          search: searchTerm,
+          mode: "insensitive",
+        },
+        reviews: {
+          some: {
+            reports: {
+              some: {
+                issues: {
+                  some: {
+                    text: {
+                      not: "",
+                    },
                   },
                 },
               },
@@ -58,18 +64,27 @@ export async function action({ request }: ActionArgs) {
           },
         },
       },
-    },
-    orderBy: {
-      _relevance: {
-        fields: ["name"],
-        search: searchTerm,
-        sort: "desc",
+      orderBy: {
+        _relevance: {
+          fields: ["name"],
+          search: searchTerm,
+          sort: "desc",
+        },
       },
-    },
-    select: {
-      id: true,
-    },
-  });
+      select: {
+        id: true,
+      },
+    });
+  } catch (e) {
+    const prismaError = e as PrismaClientError;
+    if (prismaError) {
+      console.error(prismaError.message);
+      return json({ error: PRISMA_ERROR_MSG }, { status: 500 });
+    } else {
+      console.error(e);
+      throw e;
+    }
+  }
   if (!data) {
     return json({ error: "Product not found" }, { status: 400 });
   }

--- a/server/app/routes/admin.users.tsx
+++ b/server/app/routes/admin.users.tsx
@@ -84,6 +84,15 @@ export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
   const action = formData.get("action");
 
+  const { supabase, headers } = createServerClient(request);
+
+  if (!(await isAdmin(supabase))) {
+    return json(
+      { error: "Requesting user is not an administrator or is not logged in" },
+      { status: 400, headers }
+    );
+  }
+
   if (action === "role") {
     const id = formData.get("id");
     const role = formData.get("role");
@@ -97,14 +106,14 @@ export const action: ActionFunction = async ({ request }) => {
     ) {
       return json(
         { error: "Users page backend error: Incomplete Request" },
-        { status: 400 }
+        { status: 400, headers }
       );
     }
 
     if (role !== ADMIN_ROLE_NAME) {
       return json(
         { error: `Users page backend error: Invalid Role '${role}'` },
-        { status: 400 }
+        { status: 400, headers }
       );
     }
 
@@ -139,13 +148,13 @@ export const action: ActionFunction = async ({ request }) => {
       },
     });
 
-    return json({ ok: true });
+    return json({ ok: true }, { headers });
   } else {
     const userId = formData.get("userId");
     if (!userId || !(typeof userId === "string")) {
       return json(
         { error: "Users page backend error: Incomplete Request" },
-        { status: 400 }
+        { status: 400, headers }
       );
     }
     await db.user.create({
@@ -153,7 +162,7 @@ export const action: ActionFunction = async ({ request }) => {
         id: userId,
       },
     });
-    return json({ ok: true });
+    return json({ ok: true }, { headers });
   }
 };
 

--- a/server/app/routes/auth.login.tsx
+++ b/server/app/routes/auth.login.tsx
@@ -44,7 +44,7 @@ export const action: ActionFunction = async ({ request }) => {
 
   // Reject for validation errors
   if (Object.keys(errors).length > 0) {
-    return json({ errors });
+    return json({ errors }, { status: 400, headers });
   }
 
   const data = await supabase.auth.signInWithPassword({
@@ -59,7 +59,7 @@ export const action: ActionFunction = async ({ request }) => {
 
   // Reject for Supabase errors
   if (Object.keys(errors).length > 0) {
-    return json({ errors });
+    return json({ errors }, { status: 400, headers });
   }
 
   return redirect("/", {

--- a/server/app/routes/auth.signup.tsx
+++ b/server/app/routes/auth.signup.tsx
@@ -38,7 +38,7 @@ export const action: ActionFunction = async ({ request }) => {
 
   // Reject for validation errors
   if (Object.keys(errors).length > 0) {
-    return json({ errors });
+    return json({ errors }, { status: 400, headers });
   }
 
   const data = await supabase.auth.signUp({
@@ -53,7 +53,7 @@ export const action: ActionFunction = async ({ request }) => {
 
   // Reject for Supabase errors
   if (Object.keys(errors).length > 0) {
-    return json({ errors });
+    return json({ errors }, { status: 400, headers });
   }
 
   return redirect("/auth/success", {

--- a/server/app/types/PrismaClientError.ts
+++ b/server/app/types/PrismaClientError.ts
@@ -1,0 +1,17 @@
+import type {
+  PrismaClientInitializationError,
+  PrismaClientKnownRequestError,
+  PrismaClientRustPanicError,
+  PrismaClientUnknownRequestError,
+  PrismaClientValidationError,
+} from "@prisma/client/runtime";
+
+export type PrismaClientError =
+  | PrismaClientKnownRequestError
+  | PrismaClientUnknownRequestError
+  | PrismaClientRustPanicError
+  | PrismaClientInitializationError
+  | PrismaClientValidationError;
+
+export const PRISMA_ERROR_MSG =
+  "Internal database error, please try again later";


### PR DESCRIPTION
- Catch errors thrown by Prisma on user-facing pages (index, product)
- Show caught errors (validation and prisma) to the user on index page - Closes #120
- Standardize error handling for forms: throw HTTP 400 on validation failure for login & signup to match other pages - Closes #109
- Add extra auth/admin check for Admin: User Management page action (shouldn't be triggered since the loader has route protection, but just in case someone submits a POST directly to the route somehow)
- Prevent Admin: User Management page from crashing the app if the user is already in the database - Fixes #119