### PR TITLE
fix: fix logic error in top issue classification & top issue layout

### DIFF
--- a/server/app/routes/product.$productId.tsx
+++ b/server/app/routes/product.$productId.tsx
@@ -309,7 +309,7 @@ export default function Route() {
                   key={issue.text}
                   className={`${buttonVariants({
                     variant: "secondary",
-                  })} h-min !justify-start !whitespace-normal`}
+                  })} h-min w-full !justify-start !whitespace-normal`}
                   onClick={() => {
                     setSelectedProduct(issue.id);
                   }}

--- a/server/app/utils/product.ts
+++ b/server/app/utils/product.ts
@@ -36,11 +36,15 @@ export function getTopIssues(
   };
 
   // Adds classified issues with priority
-  addIssues((classification) => classification !== "UNKNOWN_ISSUE");
+  addIssues(
+    (classification) => !!classification && classification !== "UNKNOWN_ISSUE"
+  );
 
   // Adds unclassified issues if needed
   if (issues.length < 5) {
-    addIssues((classification) => classification === "UNKNOWN_ISSUE");
+    addIssues(
+      (classification) => !classification || classification === "UNKNOWN_ISSUE"
+    );
   }
 
   return issues;


### PR DESCRIPTION
Closes #142 - The logical error was a lack of handling of falsy objects (namely, empty strings)
Closes #149